### PR TITLE
Change progressbar style

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -33,21 +33,25 @@
 }
 
 .local_chunkupload .chunkupload-label .chunkupload-left .chunkupload-filename {
-    width: 70%;
+    width: 100%;
     overflow: hidden;
     display: inline-block;
     text-overflow: ellipsis;
+    position: absolute;
+    left: 0;
 }
 
 .local_chunkupload .chunkupload-label .chunkupload-progress {
     position: absolute;
     bottom: 0;
     left: 0;
-    height: 6px;
-    background: #578014;
+    height: 100%;
+    background: #71A81A;
 }
 
 .local_chunkupload .chunkupload-label .chunkupload-icon {
+    position: absolute;
+    left: 8px;
     display: inline-block;
     vertical-align: top;
     color: green;

--- a/templates/filepicker.mustache
+++ b/templates/filepicker.mustache
@@ -42,8 +42,8 @@
                 <span class="chunkupload-icon" {{^showicon}}hidden{{/showicon}}>
                     {{#pix}}i/checked, core,{{#str}} uploaded, local_chunkupload {{/str}}{{/pix}}
                 </span>
-                <span class="chunkupload-filename">{{filenamestring}}</span>
                 <span class="chunkupload-progress"></span>
+                <span class="chunkupload-filename">{{filenamestring}}</span>
             </span>
         </label>
         <span class="chunkupload-delete"  {{^showdelete}}hidden{{/showdelete}}>{{#pix}}i/delete, core,{{#str}} deletefile, local_chunkupload {{/str}}{{/pix}}</span>


### PR DESCRIPTION
By adjusting the design of the progress bar to utilize the entire height available rather than being restricted to a mere 6 pixels, we significantly enhance its visibility and prominence on the interface, making it stand out more clearly and effectively draw the user's attention.

<img width="1594" height="179" alt="Bildschirmfoto vom 2025-08-11 18-18-59" src="https://github.com/user-attachments/assets/41be5bc7-5926-4899-b9d4-e7cd6e429f8b" />

I slightly adjusted the progress bar color to pass the contrast checker. https://webaim.org/resources/contrastchecker/?fcolor=000000&bcolor=71A81A

At the TU Wien, we have been using this style for 3 years, as we got the feedback that the smaller progress bar was easy to miss. 
